### PR TITLE
Update TicketMachine.java

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/TicketMachine.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/TicketMachine.java
@@ -22,7 +22,7 @@ public class TicketMachine {
     public void inserir(int quantia) throws PapelMoedaInvalidaException {
         boolean achou = false;
         for (int i = 0; i < papelMoeda.length && !achou; i++) {
-            if (papelMoeda[1] == quantia) {
+            if (papelMoeda[i] == quantia) {
                 achou = true;
             }
         }


### PR DESCRIPTION
A comparação usa papelMoeda[1] em vez de papelMoeda[i], resultando no reconhecimento incorreto de valores de notas.